### PR TITLE
feat: add kapi worker event watcher

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 
 use crate::events::MessageFormat;
+use crate::source::kapi::KapiWatchOptions;
 
 pub const DEFAULT_RETRY_ENTER_COUNT: u32 = 4;
 pub const DEFAULT_RETRY_ENTER_DELAY_MS: u64 = 250;
@@ -75,6 +76,11 @@ pub enum Commands {
     Tmux {
         #[command(subcommand)]
         command: TmuxCommands,
+    },
+    /// Watch Kapi worker events and forward them through clawhip.
+    Kapi {
+        #[command(subcommand)]
+        command: KapiCommands,
     },
     /// Install clawhip from the current git clone.
     Install {
@@ -390,6 +396,63 @@ pub struct TmuxWatchArgs {
     pub repo_path: Option<String>,
     #[arg(long)]
     pub branch: Option<String>,
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum KapiCommands {
+    /// Poll `kapi events` and forward worker events to the local daemon.
+    Watch(KapiWatchArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KapiWatchArgs {
+    /// Repository root to pass to `kapi events --from`.
+    #[arg(long)]
+    pub from: PathBuf,
+    /// Discord channel id/name to use as the route hint.
+    #[arg(long)]
+    pub channel: Option<String>,
+    /// Mention to include when Kapi recommends a follow-up action.
+    #[arg(long)]
+    pub mention: Option<String>,
+    /// Stale threshold metadata to preserve on forwarded events.
+    #[arg(long, default_value_t = 5)]
+    pub stale_minutes: u64,
+    /// Message format for forwarded Kapi events.
+    #[arg(long, value_enum, default_value = "compact")]
+    pub format: MessageFormat,
+    /// Persisted cursor file. Defaults to CLAWHIP_STATE_DIR/HOME based path.
+    #[arg(long)]
+    pub cursor_file: Option<PathBuf>,
+    /// Poll interval for continuous watch mode.
+    #[arg(long, default_value_t = 15)]
+    pub poll_interval_secs: u64,
+    /// Poll once, forward available events, persist the cursor, then exit.
+    #[arg(long, default_value_t = false)]
+    pub once: bool,
+    /// Exact Discord thread/topic id to preserve for downstream routing.
+    #[arg(long)]
+    pub discord_topic_id: Option<String>,
+    /// Fail fast unless --discord-topic-id is provided.
+    #[arg(long, default_value_t = false)]
+    pub require_discord_topic: bool,
+}
+
+impl From<KapiWatchArgs> for KapiWatchOptions {
+    fn from(args: KapiWatchArgs) -> Self {
+        Self {
+            from: args.from,
+            channel: args.channel,
+            mention: args.mention,
+            stale_minutes: args.stale_minutes,
+            format: args.format,
+            cursor_file: args.cursor_file,
+            poll_interval_secs: args.poll_interval_secs,
+            once: args.once,
+            discord_topic_id: args.discord_topic_id,
+            require_discord_topic: args.require_discord_topic,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -754,6 +817,49 @@ mod tests {
         };
 
         assert!(matches!(command, PluginCommands::List));
+    }
+
+    #[test]
+    fn parses_kapi_watch_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "kapi",
+            "watch",
+            "--from",
+            "/repo/kapi",
+            "--channel",
+            "alerts",
+            "--mention",
+            "<@123>",
+            "--stale-minutes",
+            "7",
+            "--format",
+            "inline",
+            "--cursor-file",
+            "/tmp/kapi.cursor",
+            "--poll-interval-secs",
+            "3",
+            "--once",
+            "--discord-topic-id",
+            "456",
+            "--require-discord-topic",
+        ]);
+
+        let Commands::Kapi { command } = cli.command.expect("kapi command") else {
+            panic!("expected kapi command");
+        };
+        let KapiCommands::Watch(args) = command;
+
+        assert_eq!(args.from, PathBuf::from("/repo/kapi"));
+        assert_eq!(args.channel.as_deref(), Some("alerts"));
+        assert_eq!(args.mention.as_deref(), Some("<@123>"));
+        assert_eq!(args.stale_minutes, 7);
+        assert!(matches!(args.format, MessageFormat::Inline));
+        assert_eq!(args.cursor_file, Some(PathBuf::from("/tmp/kapi.cursor")));
+        assert_eq!(args.poll_interval_secs, 3);
+        assert!(args.once);
+        assert_eq!(args.discord_topic_id.as_deref(), Some("456"));
+        assert!(args.require_discord_topic);
     }
 
     #[test]

--- a/src/events.rs
+++ b/src/events.rs
@@ -1366,6 +1366,33 @@ mod tests {
     }
 
     #[test]
+    fn renders_kapi_worker_events_with_actionable_context() {
+        let event = IncomingEvent {
+            kind: "kapi.worker.review-ready".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "repo_name": "devkade/kapi",
+                "slug": "issue-58-watchdog",
+                "status": "review-ready",
+                "reason": "terminal marker matched: review-ready",
+                "recommended_action": "kapi report issue-58-watchdog --from /repo/kapi --json"
+            }),
+        };
+
+        assert_eq!(
+            event.render_default(&MessageFormat::Compact).unwrap(),
+            "kapi devkade/kapi/issue-58-watchdog review-ready · reason=terminal marker matched: review-ready · action=kapi report issue-58-watchdog --from /repo/kapi --json"
+        );
+        assert_eq!(
+            event.render_default(&MessageFormat::Inline).unwrap(),
+            "[kapi:issue-58-watchdog] review-ready · devkade/kapi · review-ready · terminal marker matched: review-ready · kapi report issue-58-watchdog --from /repo/kapi --json"
+        );
+    }
+
+    #[test]
     fn git_commit_events_keep_single_commit_rendering() {
         let events = IncomingEvent::git_commit_events(
             "repo".into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ use std::sync::Arc;
 use clap::Parser;
 
 use crate::cli::{
-    AgentCommands, Cli, Commands, ConfigCommand, GitCommands, GithubCommands, MemoryCommands,
-    PluginCommands, TmuxCommands,
+    AgentCommands, Cli, Commands, ConfigCommand, GitCommands, GithubCommands, KapiCommands,
+    MemoryCommands, PluginCommands, TmuxCommands,
 };
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
@@ -205,6 +205,12 @@ async fn real_main() -> Result<()> {
             }
             TmuxCommands::New(args) => tmux_wrapper::run(args, config.as_ref()).await,
             TmuxCommands::Watch(args) => tmux_wrapper::watch(args, config.as_ref()).await,
+        },
+        Commands::Kapi { command } => match command {
+            KapiCommands::Watch(args) => {
+                let client = DaemonClient::from_config(config.as_ref());
+                crate::source::kapi::watch_daemon(client, args.into()).await
+            }
         },
         Commands::Config { command } => match command.unwrap_or(ConfigCommand::Interactive) {
             ConfigCommand::Interactive => {

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -17,6 +17,9 @@ impl Renderer for DefaultRenderer {
         if event.canonical_kind().starts_with("session.") {
             return render_session_event(event.canonical_kind(), payload, format);
         }
+        if event.canonical_kind().starts_with("kapi.worker.") {
+            return render_kapi_worker_event(event.canonical_kind(), payload, format);
+        }
         if event.canonical_kind() == "git.commit"
             && let Some(rendered) = render_aggregated_git_commit(payload, format)?
         {
@@ -353,6 +356,53 @@ fn agent_inline_suffix(payload: &Value) -> String {
         String::new()
     } else {
         format!(" · {}", parts.join(" · "))
+    }
+}
+
+fn render_kapi_worker_event(kind: &str, payload: &Value, format: &MessageFormat) -> Result<String> {
+    let event = kind.strip_prefix("kapi.worker.").unwrap_or(kind);
+    let repo = optional_string_field(payload, "repo_name")
+        .or_else(|| optional_string_field(payload, "repo"))
+        .unwrap_or_else(|| "unknown-repo".to_string());
+    let slug = optional_string_field(payload, "slug")
+        .or_else(|| optional_string_field(payload, "worker_id"))
+        .unwrap_or_else(|| "unknown-worker".to_string());
+    let status = optional_string_field(payload, "status").unwrap_or_else(|| event.to_string());
+    let reason = optional_string_field(payload, "reason");
+    let action = optional_string_field(payload, "recommended_action");
+
+    match format {
+        MessageFormat::Compact => {
+            let mut parts = vec![format!("kapi {repo}/{slug} {status}")];
+            if let Some(reason) = reason {
+                parts.push(format!("reason={reason}"));
+            }
+            if let Some(action) = action {
+                parts.push(format!("action={action}"));
+            }
+            Ok(parts.join(" · "))
+        }
+        MessageFormat::Alert => {
+            let mut rendered = format!("🚨 kapi {repo}/{slug} {status}");
+            if let Some(reason) = reason {
+                rendered.push_str(&format!(" · {reason}"));
+            }
+            if let Some(action) = action {
+                rendered.push_str(&format!(" · run: {action}"));
+            }
+            Ok(rendered)
+        }
+        MessageFormat::Inline => {
+            let mut parts = vec![format!("[kapi:{slug}] {event}"), repo, status];
+            if let Some(reason) = reason {
+                parts.push(reason);
+            }
+            if let Some(action) = action {
+                parts.push(action);
+            }
+            Ok(parts.join(" · "))
+        }
+        MessageFormat::Raw => Ok(serde_json::to_string_pretty(payload)?),
     }
 }
 

--- a/src/source/kapi.rs
+++ b/src/source/kapi.rs
@@ -1,0 +1,317 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde_json::{Map, Value, json};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use crate::Result;
+use crate::client::DaemonClient;
+use crate::events::{IncomingEvent, MessageFormat};
+
+#[derive(Debug, Clone)]
+pub struct KapiWatchOptions {
+    pub from: PathBuf,
+    pub channel: Option<String>,
+    pub mention: Option<String>,
+    pub stale_minutes: u64,
+    pub format: MessageFormat,
+    pub cursor_file: Option<PathBuf>,
+    pub poll_interval_secs: u64,
+    pub once: bool,
+    pub discord_topic_id: Option<String>,
+    pub require_discord_topic: bool,
+}
+
+impl KapiWatchOptions {
+    pub fn resolved_cursor_file(&self) -> PathBuf {
+        self.cursor_file.clone().unwrap_or_else(|| {
+            let repo_key = sanitize_cursor_key(&self.from.to_string_lossy());
+            default_cursor_dir().join(format!("{repo_key}.cursor"))
+        })
+    }
+}
+
+pub async fn watch_daemon(client: DaemonClient, options: KapiWatchOptions) -> Result<()> {
+    validate_options(&options)?;
+    loop {
+        let events = poll_kapi_events(&options).await?;
+        for event in &events.events {
+            client.send_event(event).await?;
+        }
+        if let Some(cursor) = events.cursor {
+            write_cursor(&options.resolved_cursor_file(), &cursor)?;
+        }
+        if options.once {
+            break;
+        }
+        sleep(Duration::from_secs(options.poll_interval_secs.max(1))).await;
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+pub async fn watch_source(
+    options: KapiWatchOptions,
+    tx: mpsc::Sender<IncomingEvent>,
+) -> Result<()> {
+    validate_options(&options)?;
+    loop {
+        let events = poll_kapi_events(&options).await?;
+        for event in &events.events {
+            tx.send(event.clone()).await?;
+        }
+        if let Some(cursor) = events.cursor {
+            write_cursor(&options.resolved_cursor_file(), &cursor)?;
+        }
+        if options.once {
+            break;
+        }
+        sleep(Duration::from_secs(options.poll_interval_secs.max(1))).await;
+    }
+    Ok(())
+}
+
+fn validate_options(options: &KapiWatchOptions) -> Result<()> {
+    if options.require_discord_topic && options.discord_topic_id.is_none() {
+        return Err("--require-discord-topic requires --discord-topic-id".into());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+pub struct KapiPollResult {
+    pub events: Vec<IncomingEvent>,
+    pub cursor: Option<String>,
+}
+
+async fn poll_kapi_events(options: &KapiWatchOptions) -> Result<KapiPollResult> {
+    let since = read_cursor(&options.resolved_cursor_file())?;
+    let mut command = Command::new("kapi");
+    command
+        .arg("events")
+        .arg("--from")
+        .arg(&options.from)
+        .arg("--json");
+    if let Some(cursor) = since.as_deref().filter(|cursor| !cursor.is_empty()) {
+        command.arg("--since").arg(cursor);
+    }
+
+    let output = command.output().await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Err(format!(
+            "kapi events failed with status {}: {}{}",
+            output.status,
+            stderr,
+            if stdout.is_empty() {
+                String::new()
+            } else {
+                format!("\nstdout: {stdout}")
+            }
+        )
+        .into());
+    }
+
+    let value: Value = serde_json::from_slice(&output.stdout)?;
+    parse_kapi_events(value, options)
+}
+
+pub fn parse_kapi_events(value: Value, options: &KapiWatchOptions) -> Result<KapiPollResult> {
+    let raw_events: Vec<Value> = match value {
+        Value::Array(events) => events,
+        Value::Object(mut object) => object
+            .remove("events")
+            .or_else(|| object.remove("items"))
+            .and_then(|events| events.as_array().cloned())
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    };
+
+    let mut cursor = None;
+    let mut events = Vec::new();
+    for raw in raw_events {
+        let Some(event) = event_from_kapi_value(raw, options)? else {
+            continue;
+        };
+        if let Some(next_cursor) = event
+            .payload
+            .get("cursor")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        {
+            cursor = Some(next_cursor);
+        }
+        events.push(event);
+    }
+
+    Ok(KapiPollResult { events, cursor })
+}
+
+fn event_from_kapi_value(raw: Value, options: &KapiWatchOptions) -> Result<Option<IncomingEvent>> {
+    let Value::Object(mut object) = raw else {
+        return Ok(None);
+    };
+
+    let event_type = object
+        .remove("type")
+        .or_else(|| object.remove("kind"))
+        .or_else(|| object.remove("event"))
+        .and_then(|value| value.as_str().map(str::to_string))
+        .ok_or("kapi event is missing type")?;
+
+    if !event_type.starts_with("kapi.worker.") {
+        return Ok(None);
+    }
+
+    let payload = object
+        .remove("payload")
+        .and_then(|payload| payload.as_object().cloned())
+        .unwrap_or_else(|| object.clone());
+    let mut payload = payload;
+
+    payload
+        .entry("repo")
+        .or_insert_with(|| json!(options.from.display().to_string()));
+    payload
+        .entry("stale_minutes")
+        .or_insert_with(|| json!(options.stale_minutes));
+    if let Some(topic) = &options.discord_topic_id {
+        payload
+            .entry("discord_topic_id")
+            .or_insert_with(|| json!(topic));
+    }
+
+    Ok(Some(IncomingEvent {
+        kind: event_type,
+        channel: options.channel.clone(),
+        mention: mention_for_event(&payload, options),
+        format: Some(options.format.clone()),
+        template: None,
+        payload: Value::Object(payload),
+    }))
+}
+
+fn mention_for_event(payload: &Map<String, Value>, options: &KapiWatchOptions) -> Option<String> {
+    let needs_followup = payload
+        .get("recommended_action")
+        .and_then(Value::as_str)
+        .map(|action| !action.trim().is_empty())
+        .unwrap_or(false);
+    if needs_followup {
+        options.mention.clone()
+    } else {
+        None
+    }
+}
+
+fn read_cursor(path: &Path) -> Result<Option<String>> {
+    match std::fs::read_to_string(path) {
+        Ok(cursor) => Ok(Some(cursor.trim().to_string()).filter(|cursor| !cursor.is_empty())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn write_cursor(path: &Path, cursor: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, cursor)?;
+    Ok(())
+}
+
+fn default_cursor_dir() -> PathBuf {
+    std::env::var_os("CLAWHIP_STATE_DIR")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".clawhip")))
+        .unwrap_or_else(|| PathBuf::from(".clawhip"))
+        .join("kapi")
+        .join("cursors")
+}
+
+fn sanitize_cursor_key(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn options() -> KapiWatchOptions {
+        KapiWatchOptions {
+            from: PathBuf::from("/repo/kapi"),
+            channel: Some("alerts".into()),
+            mention: Some("<@123>".into()),
+            stale_minutes: 5,
+            format: MessageFormat::Compact,
+            cursor_file: None,
+            poll_interval_secs: 1,
+            once: true,
+            discord_topic_id: Some("456".into()),
+            require_discord_topic: false,
+        }
+    }
+
+    #[test]
+    fn parses_kapi_worker_events_and_preserves_cursor() {
+        let result = parse_kapi_events(
+            json!({
+                "events": [{
+                    "type": "kapi.worker.review-ready",
+                    "payload": {
+                        "repo_name": "devkade/kapi",
+                        "slug": "issue-58",
+                        "status": "review-ready",
+                        "reason": "terminal marker matched",
+                        "recommended_action": "kapi report issue-58 --from /repo/kapi --json",
+                        "cursor": "abc123"
+                    }
+                }]
+            }),
+            &options(),
+        )
+        .expect("parse result");
+
+        assert_eq!(result.cursor.as_deref(), Some("abc123"));
+        assert_eq!(result.events.len(), 1);
+        let event = &result.events[0];
+        assert_eq!(event.kind, "kapi.worker.review-ready");
+        assert_eq!(event.channel.as_deref(), Some("alerts"));
+        assert_eq!(event.mention.as_deref(), Some("<@123>"));
+        assert_eq!(event.payload["repo_name"], json!("devkade/kapi"));
+        assert_eq!(event.payload["discord_topic_id"], json!("456"));
+    }
+
+    #[test]
+    fn filters_non_kapi_worker_events() {
+        let result = parse_kapi_events(
+            json!([
+                {"type": "kapi.worker.started", "payload": {"cursor": "one"}},
+                {"type": "tmux.keyword", "payload": {"cursor": "two"}}
+            ]),
+            &options(),
+        )
+        .expect("parse result");
+
+        assert_eq!(result.events.len(), 1);
+        assert_eq!(result.cursor.as_deref(), Some("one"));
+    }
+
+    #[test]
+    fn require_topic_fails_fast_without_topic() {
+        let mut options = options();
+        options.discord_topic_id = None;
+        options.require_discord_topic = true;
+
+        let error = validate_options(&options).expect_err("topic should be required");
+        assert!(error.to_string().contains("--require-discord-topic"));
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,6 +5,7 @@ use crate::events::IncomingEvent;
 
 pub mod git;
 pub mod github;
+pub mod kapi;
 pub mod tmux;
 
 pub use git::GitSource;


### PR DESCRIPTION
## Summary
- Adds `clawhip kapi watch` as a Kapi worker-event observer surface.
- Polls `kapi events --from <repo> --since <cursor> --json`, converts `kapi.worker.*` events into normal clawhip `IncomingEvent`s, and persists cursors.
- Adds compact/inline/alert rendering for Kapi worker alerts with repo, slug, status, reason, and recommended action.

## Linked issue
Closes #2

## Problem
Kapi should remain the semantic worker event source, while clawhip owns external observation, routing, and Discord delivery. clawhip did not have a Kapi-oriented source/command, so Hermes/Ragna could not consume Kapi worker lifecycle events through the normal clawhip routing/sink path.

## Options considered
1. **Extend raw tmux monitoring for Kapi workers**
   - Pros: Reuses existing tmux source code.
   - Cons: Violates the issue direction; raw pane keyword grep is not the source of truth for Kapi worker lifecycle state.
2. **Add a Kapi-specific watch command/source adapter**
   - Pros: Keeps Kapi as semantic source, preserves `kapi.worker.*` payloads, and uses clawhip for transport/routing.
   - Cons: Live delivery depends on Kapi shipping the companion `events` command.
3. **Embed a Kapi Discord bot/daemon**
   - Pros: Direct notifications from Kapi.
   - Cons: Explicit non-goal; duplicates clawhip responsibilities.

## Selected approach
Selected option 2: add a Kapi watch adapter in clawhip.

This keeps the architecture split intact:

```text
Kapi = semantic event source
clawhip = observer / routing / delivery
Hermes/Ragna = inspection / follow-up
```

Trade-off: the local Kapi checkout currently does not expose `kapi events`, so full live smoke is blocked until the Kapi companion issue lands. The clawhip side now implements the expected contract and fails with the underlying command error when unavailable.

## Implementation
- Added `clawhip kapi watch --from <repo> ...` CLI surface.
- Added `src/source/kapi.rs` to:
  - read persisted cursor
  - run `kapi events --from <repo> --since <cursor> --json`
  - parse array or `{ events: [...] }` JSON outputs
  - filter/preserve `kapi.worker.*` events
  - attach channel/format/optional mention metadata
  - preserve `discord_topic_id` in payload and optionally fail fast when required
  - persist latest event cursor
- Wired the command through `main.rs` via the existing daemon client, so events enter the normal `/event` pipeline.
- Added Kapi worker rendering for compact/alert/inline/raw formats.
- Added unit tests for CLI parsing, Kapi event parsing/cursor behavior, topic requirement validation, and rendering.

## Why this fixes it
The new adapter gives clawhip a Kapi-first observer surface without moving notification ownership into Kapi. `kapi.worker.*` events are converted into normal clawhip events, allowing existing router/renderer/sink behavior to deliver actionable alerts with `recommended_action` visible.

## QA / Verification
- [x] `cargo test` — pass, 151 unit tests + 5 integration tests.
- [x] `cargo run -- kapi watch --help` — pass, command and flag help render correctly.
- [x] `git diff --check` — pass.
- [x] Kapi repo-generic command attempt: `node --import tsx ./src/cli/kapi-cli.ts start ralph "Implement clawhip issue #2 Kapi worker event source slice" --from /Users/devkade/projects/claw/clawhip-issue2 --slug ralph-clawhip-issue2-kapi-source --json` — worker/worktree created, but prompt dispatch failed with `manual-attach-required` because readiness response was not observed.
- [ ] Live smoke: `Kapi worker event → clawhip alert → Hermes/Ragna runs kapi report` — blocked because the current local Kapi CLI does not expose `events` yet (`Unknown kapi command: events`) and `kapi` is not installed on PATH for direct `clawhip kapi watch` execution.

## Kapi anomalies observed
- `node --import tsx ... kapi-cli.ts events --from /Users/devkade/projects/claw/clawhip-issue2 --json` fails with `Unknown kapi command: events`; the companion Kapi event stream appears not landed in the inspected checkout.
- `clawhip kapi watch --once` currently fails locally with `No such file or directory (os error 2)` because `kapi` is not on PATH in this shell.
- Kapi repo-generic `start ralph --from /Users/devkade/projects/claw/clawhip-issue2` can create a non-Kapi worker worktree, but Pi readiness/prompt dispatch failed (`manual-attach-required`, readiness response not observed).
- `node --import tsx` must be run from the Kapi repo; running it from clawhip failed to resolve `tsx`.

## Risks / Follow-up
- Exact Discord thread/topic delivery is preserved as payload metadata and can fail fast via `--require-discord-topic`, but full route/sink-level thread delivery is left for #5.
- Dedupe/repeat notification policy beyond cursor persistence is left for #4.
- Live smoke remains blocked until Kapi ships/installs the `events` command surface expected by #2.
