### PR TITLE
feat: add compact Kapi worker alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 target/
+.kapi/

--- a/README.md
+++ b/README.md
@@ -567,7 +567,42 @@ Verification:
 - emit keyword in pane
 - confirm Discord message body and mention
 
-### 12. install lifecycle preset
+### 12. Kapi worker alert preset
+
+Input:
+```json
+{
+  "kind": "kapi.worker.review-ready",
+  "payload": {
+    "repo": "devkade/kapi",
+    "slug": "issue-78-registry-hardening",
+    "branch": "feat/issue-78-registry-hardening",
+    "mode": "ralph",
+    "reason": "candidate-ready",
+    "summary": "worker reports candidate implementation + verification",
+    "recommended": "kapi report issue-78-registry-hardening --from /repo --json"
+  }
+}
+```
+
+Behavior:
+- render `kapi.worker.*` events as compact, scannable `[kapi]` summaries instead of raw JSON
+- dedupe repeated identical worker alerts in the daemon dispatcher
+- allow repeated `kapi.worker.stale` notifications only after `[kapi_alerts].stale_repeat_secs` (default 900s)
+- prepend route/event mentions only for action-worthy worker states (`blocked`, `failed`, `stale`, `review-ready`, `candidate-ready`, `merge-ready`)
+
+Configuration:
+```toml
+[kapi_alerts]
+stale_repeat_secs = 900
+```
+
+Verification:
+- POST duplicate `kapi.worker.running` events and confirm only the first is delivered
+- POST `kapi.worker.blocked` or `kapi.worker.review-ready` with a route mention and confirm the mention is kept
+- POST `kapi.worker.running` with a route mention and confirm the message is not a ping
+
+### 13. install lifecycle preset
 
 Input:
 ```bash

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Result;
 use crate::events::MessageFormat;
+use crate::kapi_alert::KapiAlertConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AppConfig {
@@ -23,6 +24,8 @@ pub struct AppConfig {
     pub routes: Vec<RouteRule>,
     #[serde(default)]
     pub monitors: MonitorConfig,
+    #[serde(default)]
+    pub kapi_alerts: KapiAlertConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -678,6 +678,12 @@ mod tests {
             payload["summary"]["tool_hint_counts"]["cargo test"],
             Value::from(1)
         );
-        assert_eq!(payload["summary"]["tool_error_sessions"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            payload["summary"]["tool_error_sessions"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
     }
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -4,6 +4,7 @@ use tokio::sync::mpsc;
 
 use crate::Result;
 use crate::events::IncomingEvent;
+use crate::kapi_alert::KapiAlertDedupe;
 use crate::render::Renderer;
 use crate::router::Router;
 use crate::sink::{Sink, SinkMessage};
@@ -13,6 +14,8 @@ pub struct Dispatcher {
     router: Router,
     renderer: Box<dyn Renderer>,
     sinks: HashMap<String, Box<dyn Sink>>,
+    kapi_dedupe: KapiAlertDedupe,
+    kapi_stale_repeat_secs: u64,
 }
 
 impl Dispatcher {
@@ -22,16 +25,26 @@ impl Dispatcher {
         renderer: Box<dyn Renderer>,
         sinks: HashMap<String, Box<dyn Sink>>,
     ) -> Self {
+        let kapi_stale_repeat_secs = router.kapi_stale_repeat_secs();
         Self {
             rx,
             router,
             renderer,
             sinks,
+            kapi_dedupe: KapiAlertDedupe::default(),
+            kapi_stale_repeat_secs,
         }
     }
 
     pub async fn run(&mut self) -> Result<()> {
         while let Some(event) = self.rx.recv().await {
+            if !self
+                .kapi_dedupe
+                .should_emit_now(&event, self.kapi_stale_repeat_secs)
+            {
+                continue;
+            }
+
             let deliveries = match self.router.resolve(&event).await {
                 Ok(deliveries) => deliveries,
                 Err(error) => {

--- a/src/kapi_alert.rs
+++ b/src/kapi_alert.rs
@@ -1,0 +1,319 @@
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::events::IncomingEvent;
+
+pub const DEFAULT_STALE_REPEAT_SECS: u64 = 15 * 60;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct KapiAlertConfig {
+    #[serde(default = "default_stale_repeat_secs")]
+    pub stale_repeat_secs: u64,
+}
+
+impl Default for KapiAlertConfig {
+    fn default() -> Self {
+        Self {
+            stale_repeat_secs: default_stale_repeat_secs(),
+        }
+    }
+}
+
+fn default_stale_repeat_secs() -> u64 {
+    DEFAULT_STALE_REPEAT_SECS
+}
+
+#[derive(Debug, Default)]
+pub struct KapiAlertDedupe {
+    last_emitted: HashMap<String, u64>,
+}
+
+impl KapiAlertDedupe {
+    pub fn should_emit_now(&mut self, event: &IncomingEvent, stale_repeat_secs: u64) -> bool {
+        self.should_emit_at(event, unix_now_secs(), stale_repeat_secs)
+    }
+
+    pub fn should_emit_at(
+        &mut self,
+        event: &IncomingEvent,
+        now_secs: u64,
+        stale_repeat_secs: u64,
+    ) -> bool {
+        let Some(key) = dedupe_key(event) else {
+            return true;
+        };
+
+        let repeat_allowed = worker_label(event.canonical_kind()) == Some("stale");
+        match self.last_emitted.get(&key).copied() {
+            Some(last_seen)
+                if !repeat_allowed
+                    || now_secs.saturating_sub(last_seen) < stale_repeat_secs.max(1) =>
+            {
+                false
+            }
+            _ => {
+                self.last_emitted.insert(key, now_secs);
+                true
+            }
+        }
+    }
+}
+
+pub fn is_kapi_worker_event(kind: &str) -> bool {
+    kind.starts_with("kapi.worker.")
+}
+
+pub fn worker_label(kind: &str) -> Option<&str> {
+    kind.strip_prefix("kapi.worker.")
+        .map(|label| label.trim())
+        .filter(|label| !label.is_empty())
+}
+
+pub fn action_required(kind: &str, payload: &Value) -> bool {
+    let label = worker_label(kind).unwrap_or_default();
+    if matches!(
+        label,
+        "blocked" | "failed" | "stale" | "review-ready" | "candidate-ready" | "merge-ready"
+    ) {
+        return true;
+    }
+
+    let normalized_fields = ["reason", "status", "verdict", "review_state", "conclusion"]
+        .into_iter()
+        .filter_map(|key| string_field(payload, key))
+        .map(|value| normalize_token(&value))
+        .collect::<Vec<_>>();
+
+    normalized_fields.iter().any(|value| {
+        matches!(
+            value.as_str(),
+            "blocked"
+                | "failed"
+                | "stale"
+                | "review-ready"
+                | "candidate-ready"
+                | "changes-requested"
+                | "changes_requested"
+                | "approved"
+                | "merge-ready"
+        )
+    })
+}
+
+pub fn should_apply_mention(event: &IncomingEvent) -> bool {
+    !is_kapi_worker_event(event.canonical_kind())
+        || action_required(event.canonical_kind(), &event.payload)
+}
+
+pub fn render_worker_event(
+    kind: &str,
+    payload: &Value,
+    alert_prefix: bool,
+    inline: bool,
+) -> String {
+    let label = worker_label(kind).unwrap_or("event");
+    let repo = string_field(payload, "repo").unwrap_or_else(|| "unknown-repo".to_string());
+    let slug = string_field(payload, "slug").unwrap_or_else(|| "unknown-slug".to_string());
+    let mode = string_field(payload, "mode").unwrap_or_else(|| "unknown-mode".to_string());
+    let summary = string_field(payload, "summary");
+
+    if inline {
+        let mut rendered = format!("[kapi:{label}] {repo} {slug} ({mode})");
+        if let Some(summary) = summary {
+            rendered.push_str(" — ");
+            rendered.push_str(&summary);
+        }
+        return rendered;
+    }
+
+    let mut lines = vec![if alert_prefix {
+        format!("🚨 [kapi] {label}")
+    } else {
+        format!("[kapi] {label}")
+    }];
+    let recommended = recommended_action(payload, &slug);
+    push_line(&mut lines, "repo", Some(repo));
+    push_line(&mut lines, "slug", Some(slug));
+    push_line(&mut lines, "branch", string_field(payload, "branch"));
+    push_line(&mut lines, "mode", Some(mode));
+    push_line(&mut lines, "reason", string_field(payload, "reason"));
+    push_line(&mut lines, "summary", summary);
+    push_line(&mut lines, "recommended", recommended);
+    lines.join("\n")
+}
+
+fn dedupe_key(event: &IncomingEvent) -> Option<String> {
+    let kind = event.canonical_kind();
+    if !is_kapi_worker_event(kind) {
+        return None;
+    }
+
+    let payload = &event.payload;
+    let mut parts = vec![format!("kind={kind}")];
+    for key in [
+        "repo",
+        "slug",
+        "mode",
+        "branch",
+        "reason",
+        "status",
+        "summary",
+        "recommended",
+        "review_state",
+        "verdict",
+        "conclusion",
+    ] {
+        if let Some(value) = string_field(payload, key) {
+            parts.push(format!("{key}={value}"));
+        }
+    }
+
+    if action_required(kind, payload)
+        && let Some(cursor) = string_field(payload, "cursor")
+    {
+        parts.push(format!("cursor={cursor}"));
+    }
+
+    Some(parts.join("\u{1f}"))
+}
+
+fn recommended_action(payload: &Value, slug: &str) -> Option<String> {
+    string_field(payload, "recommended")
+        .or_else(|| string_field(payload, "recommended_action"))
+        .or_else(|| string_field(payload, "action"))
+        .or_else(|| {
+            string_field(payload, "repo_path")
+                .map(|repo_path| format!("kapi report {slug} --from {repo_path} --json"))
+        })
+}
+
+fn push_line(lines: &mut Vec<String>, key: &str, value: Option<String>) {
+    if let Some(value) = value {
+        lines.push(format!("{key}: {value}"));
+    }
+}
+
+fn string_field(payload: &Value, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn normalize_token(value: &str) -> String {
+    value.trim().replace(' ', "-").to_ascii_lowercase()
+}
+
+fn unix_now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn worker_event(kind: &str, payload: Value) -> IncomingEvent {
+        IncomingEvent {
+            kind: kind.into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload,
+        }
+    }
+
+    #[test]
+    fn suppresses_repeated_identical_worker_events() {
+        let event = worker_event(
+            "kapi.worker.blocked",
+            json!({
+                "repo": "devkade/kapi",
+                "slug": "issue-78",
+                "mode": "ralph",
+                "reason": "blocked",
+                "summary": "waiting for review",
+                "cursor": "abc"
+            }),
+        );
+        let mut dedupe = KapiAlertDedupe::default();
+
+        assert!(dedupe.should_emit_at(&event, 100, DEFAULT_STALE_REPEAT_SECS));
+        assert!(!dedupe.should_emit_at(&event, 101, DEFAULT_STALE_REPEAT_SECS));
+    }
+
+    #[test]
+    fn allows_stale_repeat_after_configured_interval() {
+        let event = worker_event(
+            "kapi.worker.stale",
+            json!({
+                "repo": "devkade/kapi",
+                "slug": "issue-78",
+                "mode": "ralph",
+                "reason": "stale",
+                "summary": "no output",
+                "cursor": "abc"
+            }),
+        );
+        let mut dedupe = KapiAlertDedupe::default();
+
+        assert!(dedupe.should_emit_at(&event, 100, 30));
+        assert!(!dedupe.should_emit_at(&event, 120, 30));
+        assert!(dedupe.should_emit_at(&event, 130, 30));
+    }
+
+    #[test]
+    fn running_output_growth_does_not_create_new_dedupe_key() {
+        let first = worker_event(
+            "kapi.worker.running",
+            json!({
+                "repo": "devkade/kapi",
+                "slug": "issue-78",
+                "mode": "ralph",
+                "summary": "still running",
+                "cursor": "cursor-1",
+                "output_tail": "one"
+            }),
+        );
+        let second = worker_event(
+            "kapi.worker.running",
+            json!({
+                "repo": "devkade/kapi",
+                "slug": "issue-78",
+                "mode": "ralph",
+                "summary": "still running",
+                "cursor": "cursor-2",
+                "output_tail": "one two three"
+            }),
+        );
+        let mut dedupe = KapiAlertDedupe::default();
+
+        assert!(dedupe.should_emit_at(&first, 100, DEFAULT_STALE_REPEAT_SECS));
+        assert!(!dedupe.should_emit_at(&second, 101, DEFAULT_STALE_REPEAT_SECS));
+    }
+
+    #[test]
+    fn only_action_required_worker_events_keep_mentions() {
+        let running = worker_event(
+            "kapi.worker.running",
+            json!({"repo": "devkade/kapi", "slug": "issue-78"}),
+        );
+        let blocked = worker_event(
+            "kapi.worker.blocked",
+            json!({"repo": "devkade/kapi", "slug": "issue-78"}),
+        );
+
+        assert!(!should_apply_mention(&running));
+        assert!(should_apply_mention(&blocked));
+    }
+}

--- a/src/lifecycle.rs
+++ b/src/lifecycle.rs
@@ -341,7 +341,7 @@ mod tests {
                     String::from("api"),
                     String::from("--method"),
                     String::from("PUT"),
-                    String::from(format!("/user/starred/{GITHUB_REPO}")),
+                    format!("/user/starred/{GITHUB_REPO}"),
                     String::from("--silent"),
                 ],
             ]
@@ -375,7 +375,7 @@ mod tests {
                     String::from("api"),
                     String::from("--method"),
                     String::from("PUT"),
-                    String::from(format!("/user/starred/{GITHUB_REPO}")),
+                    format!("/user/starred/{GITHUB_REPO}"),
                     String::from("--silent"),
                 ],
             ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod dispatch;
 mod dynamic_tokens;
 mod event;
 mod events;
+mod kapi_alert;
 mod keyword_window;
 mod lifecycle;
 mod memory;

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -2,6 +2,7 @@ use serde_json::Value;
 
 use crate::Result;
 use crate::events::{IncomingEvent, MessageFormat};
+use crate::kapi_alert;
 
 use super::Renderer;
 
@@ -13,6 +14,20 @@ impl Renderer for DefaultRenderer {
         let payload = &event.payload;
         if event.canonical_kind() == "pi.state-summary" {
             return render_pi_state_summary(payload, format);
+        }
+        if kapi_alert::is_kapi_worker_event(event.canonical_kind()) {
+            return Ok(match format {
+                MessageFormat::Compact => {
+                    kapi_alert::render_worker_event(event.canonical_kind(), payload, false, false)
+                }
+                MessageFormat::Alert => {
+                    kapi_alert::render_worker_event(event.canonical_kind(), payload, true, false)
+                }
+                MessageFormat::Inline => {
+                    kapi_alert::render_worker_event(event.canonical_kind(), payload, false, true)
+                }
+                MessageFormat::Raw => serde_json::to_string_pretty(payload)?,
+            });
         }
         if event.canonical_kind().starts_with("session.") {
             return render_session_event(event.canonical_kind(), payload, format);
@@ -687,5 +702,60 @@ mod tests {
         assert!(rendered.contains("running=2"));
         assert!(rendered.contains("blocked=1"));
         assert!(rendered.contains("tool-active=1"));
+    }
+
+    #[test]
+    fn renders_kapi_worker_review_ready_as_compact_action_alert() {
+        let event = IncomingEvent {
+            kind: "kapi.worker.review-ready".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "repo": "devkade/kapi",
+                "slug": "issue-78-registry-hardening",
+                "branch": "feat/issue-78-registry-hardening",
+                "mode": "ralph",
+                "reason": "candidate-ready",
+                "summary": "worker reports candidate implementation + verification",
+                "recommended": "kapi report issue-78-registry-hardening --from /repo --json"
+            }),
+        };
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Compact)
+            .unwrap();
+
+        assert_eq!(
+            rendered,
+            "[kapi] review-ready\nrepo: devkade/kapi\nslug: issue-78-registry-hardening\nbranch: feat/issue-78-registry-hardening\nmode: ralph\nreason: candidate-ready\nsummary: worker reports candidate implementation + verification\nrecommended: kapi report issue-78-registry-hardening --from /repo --json"
+        );
+    }
+
+    #[test]
+    fn renders_kapi_worker_running_without_action_prefix() {
+        let event = IncomingEvent {
+            kind: "kapi.worker.running".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "repo": "devkade/kapi",
+                "slug": "issue-78-registry-hardening",
+                "mode": "ralph",
+                "summary": "worker still running"
+            }),
+        };
+
+        let rendered = DefaultRenderer
+            .render(&event, &MessageFormat::Inline)
+            .unwrap();
+
+        assert_eq!(
+            rendered,
+            "[kapi:running] devkade/kapi issue-78-registry-hardening (ralph) — worker still running"
+        );
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -4,6 +4,7 @@ use crate::Result;
 use crate::config::{AppConfig, RouteRule, default_sink_name};
 use crate::dynamic_tokens;
 use crate::events::{IncomingEvent, MessageFormat};
+use crate::kapi_alert;
 #[cfg(test)]
 use crate::render::DefaultRenderer;
 use crate::render::Renderer;
@@ -30,6 +31,10 @@ pub struct Router {
 impl Router {
     pub fn new(config: Arc<AppConfig>) -> Self {
         Self { config }
+    }
+
+    pub fn kapi_stale_repeat_secs(&self) -> u64 {
+        self.config.kapi_alerts.stale_repeat_secs
     }
 
     #[cfg(test)]
@@ -135,8 +140,11 @@ impl Router {
             }
         };
 
-        match delivery.mention.as_deref().map(str::trim) {
-            Some(mention) if !mention.is_empty() => Ok(format!("{mention} {content}")),
+        match (
+            delivery.mention.as_deref().map(str::trim),
+            kapi_alert::should_apply_mention(event),
+        ) {
+            (Some(mention), true) if !mention.is_empty() => Ok(format!("{mention} {content}")),
             _ => Ok(content),
         }
     }
@@ -599,6 +607,63 @@ mod tests {
         let (_, _, tmux_content) = router.preview(&tmux_event).await.unwrap();
         assert!(tmux_content.starts_with("<@botid> "));
         assert!(tmux_content.contains("failed"));
+    }
+
+    #[tokio::test]
+    async fn route_level_mention_only_applies_to_actionable_kapi_worker_events() {
+        let config = AppConfig {
+            defaults: DefaultsConfig {
+                channel: Some("default".into()),
+                format: MessageFormat::Compact,
+            },
+            routes: vec![RouteRule {
+                event: "kapi.worker.*".into(),
+                sink: "discord".into(),
+                filter: Default::default(),
+                channel: Some("kapi-route".into()),
+                webhook: None,
+                slack_webhook: None,
+                mention: Some("<@botid>".into()),
+                allow_dynamic_tokens: false,
+                format: Some(MessageFormat::Compact),
+                template: None,
+            }],
+            ..AppConfig::default()
+        };
+        let router = Router::new(Arc::new(config));
+
+        let running_event = IncomingEvent {
+            kind: "kapi.worker.running".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "repo": "devkade/kapi",
+                "slug": "issue-78",
+                "mode": "ralph",
+                "summary": "worker still running"
+            }),
+        };
+        let (_, _, running_content) = router.preview(&running_event).await.unwrap();
+        assert!(!running_content.starts_with("<@botid> "));
+
+        let blocked_event = IncomingEvent {
+            kind: "kapi.worker.blocked".into(),
+            channel: None,
+            mention: None,
+            format: None,
+            template: None,
+            payload: json!({
+                "repo": "devkade/kapi",
+                "slug": "issue-78",
+                "mode": "ralph",
+                "reason": "blocked",
+                "summary": "needs review"
+            }),
+        };
+        let (_, _, blocked_content) = router.preview(&blocked_event).await.unwrap();
+        assert!(blocked_content.starts_with("<@botid> "));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Add compact rendering for canonical `kapi.worker.*` events with repo/slug/branch/mode/reason/summary/recommended action fields.
- Add dispatcher-level dedupe for repeated Kapi worker events, with configurable stale repeat interval via `[kapi_alerts].stale_repeat_secs`.
- Suppress route/event mentions for informational Kapi worker updates while keeping mentions for action-worthy states.
- Document the Kapi worker alert preset and ignore local `.kapi/` runtime registry state.

Closes #4

## Verification
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`

## Kapi notes
- Started Kapi slug `issue-4-kapi-alert-renderer-worker`, but prompt dispatch stayed `manual-attach-required` / `failed` because readiness response was not observed. Ragna proceeded directly and recorded the anomaly.