### PR TITLE
feat: add Kapi worker event watcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,34 @@ List installed plugins with:
 clawhip plugin list
 ```
 
+### Kapi worker events
+
+clawhip can watch Kapi's semantic worker event stream and route it through the normal renderer/sink pipeline:
+
+```bash
+clawhip kapi watch --from /path/to/kapi \
+  --channel YOUR_CHANNEL_OR_THREAD_ID \
+  --mention "<@hermes-bot-id>" \
+  --stale-minutes 5 \
+  --format compact
+```
+
+The watcher polls `kapi events --from <repo> --since <cursor> --json`, persists a per-repo cursor under `~/.clawhip/kapi-cursors/` by default, and emits canonical `kapi.worker.*` events. Compact rendering includes the repo, slug/worker id, status, reason, and `recommended_action` so Hermes/Ragna can follow with commands such as `kapi report <slug> --from <repo> --json`.
+
+For daemon-managed polling, configure a monitor:
+
+```toml
+[monitors]
+poll_interval_secs = 5
+
+[[monitors.kapi.repos]]
+from = "/path/to/kapi"
+channel = "YOUR_CHANNEL_OR_THREAD_ID"
+mention = "<@hermes-bot-id>"
+stale_minutes = 5
+format = "compact"
+```
+
 ## Description
 
 Operational spec for OpenClaw / Clawdbot agents consuming this repo.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: TmuxCommands,
     },
+    /// Watch Kapi worker events and forward them through clawhip.
+    Kapi {
+        #[command(subcommand)]
+        command: KapiCommands,
+    },
     /// Install clawhip from the current git clone.
     Install {
         /// Install and start the bundled systemd service.
@@ -392,6 +397,39 @@ pub struct TmuxWatchArgs {
     pub branch: Option<String>,
 }
 
+#[derive(Debug, Subcommand)]
+pub enum KapiCommands {
+    /// Poll `kapi events` and forward Kapi worker events through the local clawhip daemon.
+    Watch(KapiWatchArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct KapiWatchArgs {
+    /// Repository path passed to `kapi events --from <repo>`.
+    #[arg(long = "from")]
+    pub from: String,
+    #[arg(long)]
+    pub channel: Option<String>,
+    #[arg(long)]
+    pub mention: Option<String>,
+    #[arg(long, default_value_t = 5)]
+    pub stale_minutes: u64,
+    #[arg(long)]
+    pub format: Option<MessageFormat>,
+    /// Path for the persisted per-repo cursor. Defaults under ~/.clawhip/kapi-cursors/.
+    #[arg(long)]
+    pub cursor_path: Option<PathBuf>,
+    /// Override the kapi binary path. Also supports CLAWHIP_KAPI_BIN.
+    #[arg(long)]
+    pub kapi_bin: Option<String>,
+    /// Seconds between polls in long-running watch mode.
+    #[arg(long, default_value_t = 5)]
+    pub poll_interval_secs: u64,
+    /// Poll once and exit. Useful for smoke tests and cron-style operation.
+    #[arg(long, default_value_t = false)]
+    pub once: bool,
+}
+
 #[derive(Debug, Clone, Subcommand)]
 pub enum MemoryCommands {
     /// Create a filesystem-offloaded memory scaffold in a repo or workspace.
@@ -639,8 +677,8 @@ mod tests {
             "clawhip",
             "tmux",
             "watch",
-            "-s",
-            "issue-13",
+            "--session",
+            "issue-123",
             "--channel",
             "alerts",
             "--mention",
@@ -648,26 +686,66 @@ mod tests {
             "--keywords",
             "error,complete",
             "--stale-minutes",
-            "15",
+            "7",
             "--format",
-            "alert",
+            "inline",
         ]);
 
         let Commands::Tmux { command } = cli.command.expect("tmux command") else {
             panic!("expected tmux command");
         };
-
         let TmuxCommands::Watch(args) = command else {
-            panic!("expected tmux watch command");
+            panic!("expected tmux watch");
         };
-
-        assert_eq!(args.session, "issue-13");
+        assert_eq!(args.session, "issue-123");
         assert_eq!(args.channel.as_deref(), Some("alerts"));
         assert_eq!(args.mention.as_deref(), Some("<@123>"));
         assert_eq!(args.keywords, vec!["error", "complete"]);
-        assert_eq!(args.stale_minutes, 15);
-        assert!(args.retry_enter);
-        assert!(matches!(args.format, Some(TmuxWrapperFormat::Alert)));
+        assert_eq!(args.stale_minutes, 7);
+        assert!(matches!(args.format, Some(TmuxWrapperFormat::Inline)));
+    }
+
+    #[test]
+    fn parses_kapi_watch_subcommand() {
+        let cli = Cli::parse_from([
+            "clawhip",
+            "kapi",
+            "watch",
+            "--from",
+            "/repos/kapi",
+            "--channel",
+            "alerts",
+            "--mention",
+            "<@hermes>",
+            "--stale-minutes",
+            "5",
+            "--format",
+            "compact",
+            "--cursor-path",
+            "/tmp/kapi.cursor",
+            "--kapi-bin",
+            "/opt/bin/kapi",
+            "--poll-interval-secs",
+            "2",
+            "--once",
+        ]);
+
+        let Commands::Kapi { command } = cli.command.expect("kapi command") else {
+            panic!("expected kapi command");
+        };
+        let KapiCommands::Watch(args) = command;
+        assert_eq!(args.from, "/repos/kapi");
+        assert_eq!(args.channel.as_deref(), Some("alerts"));
+        assert_eq!(args.mention.as_deref(), Some("<@hermes>"));
+        assert_eq!(args.stale_minutes, 5);
+        assert!(matches!(args.format, Some(MessageFormat::Compact)));
+        assert_eq!(
+            args.cursor_path.as_deref(),
+            Some(std::path::Path::new("/tmp/kapi.cursor"))
+        );
+        assert_eq!(args.kapi_bin.as_deref(), Some("/opt/bin/kapi"));
+        assert_eq!(args.poll_interval_secs, 2);
+        assert!(args.once);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -172,6 +172,8 @@ pub struct MonitorConfig {
     pub git: GitMonitorConfig,
     #[serde(default)]
     pub tmux: TmuxMonitorConfig,
+    #[serde(default)]
+    pub kapi: KapiMonitorConfig,
 }
 
 impl Default for MonitorConfig {
@@ -182,6 +184,7 @@ impl Default for MonitorConfig {
             github_api_base: default_github_api_base(),
             git: GitMonitorConfig::default(),
             tmux: TmuxMonitorConfig::default(),
+            kapi: KapiMonitorConfig::default(),
         }
     }
 }
@@ -232,6 +235,39 @@ impl Default for GitRepoMonitor {
             channel: None,
             mention: None,
             format: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KapiMonitorConfig {
+    #[serde(default)]
+    pub repos: Vec<KapiRepoMonitor>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KapiRepoMonitor {
+    /// Repository path passed to `kapi events --from <repo>`.
+    pub from: String,
+    pub channel: Option<String>,
+    pub mention: Option<String>,
+    #[serde(default = "default_kapi_stale_minutes")]
+    pub stale_minutes: u64,
+    pub format: Option<MessageFormat>,
+    pub cursor_path: Option<String>,
+    pub kapi_bin: Option<String>,
+}
+
+impl Default for KapiRepoMonitor {
+    fn default() -> Self {
+        Self {
+            from: String::new(),
+            channel: None,
+            mention: None,
+            stale_minutes: default_kapi_stale_minutes(),
+            format: None,
+            cursor_path: None,
+            kapi_bin: None,
         }
     }
 }
@@ -292,6 +328,9 @@ fn default_remote() -> String {
 }
 fn default_stale_minutes() -> u64 {
     10
+}
+fn default_kapi_stale_minutes() -> u64 {
+    5
 }
 fn default_keyword_window_secs() -> u64 {
     30

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -22,7 +22,8 @@ use crate::render::{DefaultRenderer, Renderer};
 use crate::router::Router;
 use crate::sink::{DiscordSink, Sink, SlackSink};
 use crate::source::{
-    GitHubSource, GitSource, RegisteredTmuxSession, SharedTmuxRegistry, Source, TmuxSource,
+    GitHubSource, GitSource, KapiSource, RegisteredTmuxSession, SharedTmuxRegistry, Source,
+    TmuxSource,
 };
 
 const EVENT_QUEUE_CAPACITY: usize = 256;
@@ -70,6 +71,7 @@ pub async fn run(config: Arc<AppConfig>, port_override: Option<u16>) -> Result<(
         ),
         tx.clone(),
     );
+    spawn_source(KapiSource::new(config.clone()), tx.clone());
 
     let app = AxumRouter::new()
         .route("/health", get(health))
@@ -133,6 +135,7 @@ fn health_payload(config: &AppConfig, port: u16, registered_tmux_sessions: usize
         "daemon_base_url": config.daemon.base_url,
         "configured_git_monitors": config.monitors.git.repos.len(),
         "configured_tmux_monitors": config.monitors.tmux.sessions.len(),
+        "configured_kapi_monitors": config.monitors.kapi.repos.len(),
         "registered_tmux_sessions": registered_tmux_sessions,
     })
 }
@@ -678,6 +681,12 @@ mod tests {
             payload["summary"]["tool_hint_counts"]["cargo test"],
             Value::from(1)
         );
-        assert_eq!(payload["summary"]["tool_error_sessions"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            payload["summary"]["tool_error_sessions"]
+                .as_array()
+                .unwrap()
+                .len(),
+            1
+        );
     }
 }

--- a/src/kapi_wrapper.rs
+++ b/src/kapi_wrapper.rs
@@ -1,0 +1,46 @@
+use std::time::Duration;
+
+use tokio::time::sleep;
+
+use crate::Result;
+use crate::cli::KapiWatchArgs;
+use crate::client::DaemonClient;
+use crate::config::{AppConfig, KapiRepoMonitor};
+use crate::source::kapi::poll_monitor_events;
+
+pub async fn watch(args: KapiWatchArgs, config: &AppConfig) -> Result<()> {
+    let monitor = KapiRepoMonitor {
+        from: args.from.clone(),
+        channel: args.channel.clone(),
+        mention: args.mention.clone(),
+        stale_minutes: args.stale_minutes,
+        format: args.format.clone(),
+        cursor_path: args
+            .cursor_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        kapi_bin: args.kapi_bin.clone(),
+    };
+
+    loop {
+        match run_one_poll(&monitor, config).await {
+            Ok(()) => {}
+            Err(error) if args.once => return Err(error),
+            Err(error) => eprintln!("clawhip kapi watch failed for {}: {error}", monitor.from),
+        }
+
+        if args.once {
+            return Ok(());
+        }
+        sleep(Duration::from_secs(args.poll_interval_secs.max(1))).await;
+    }
+}
+
+async fn run_one_poll(monitor: &KapiRepoMonitor, config: &AppConfig) -> Result<()> {
+    let client = DaemonClient::from_config(config);
+    let (events, _outcome) = poll_monitor_events(monitor).await?;
+    for event in events {
+        client.send_event(&event).await?;
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod dispatch;
 mod dynamic_tokens;
 mod event;
 mod events;
+mod kapi_wrapper;
 mod keyword_window;
 mod lifecycle;
 mod memory;
@@ -25,8 +26,8 @@ use std::sync::Arc;
 use clap::Parser;
 
 use crate::cli::{
-    AgentCommands, Cli, Commands, ConfigCommand, GitCommands, GithubCommands, MemoryCommands,
-    PluginCommands, TmuxCommands,
+    AgentCommands, Cli, Commands, ConfigCommand, GitCommands, GithubCommands, KapiCommands,
+    MemoryCommands, PluginCommands, TmuxCommands,
 };
 use crate::client::DaemonClient;
 use crate::config::AppConfig;
@@ -205,6 +206,9 @@ async fn real_main() -> Result<()> {
             }
             TmuxCommands::New(args) => tmux_wrapper::run(args, config.as_ref()).await,
             TmuxCommands::Watch(args) => tmux_wrapper::watch(args, config.as_ref()).await,
+        },
+        Commands::Kapi { command } => match command {
+            KapiCommands::Watch(args) => kapi_wrapper::watch(args, config.as_ref()).await,
         },
         Commands::Config { command } => match command.unwrap_or(ConfigCommand::Interactive) {
             ConfigCommand::Interactive => {

--- a/src/render/default.rs
+++ b/src/render/default.rs
@@ -14,6 +14,9 @@ impl Renderer for DefaultRenderer {
         if event.canonical_kind() == "pi.state-summary" {
             return render_pi_state_summary(payload, format);
         }
+        if event.canonical_kind().starts_with("kapi.worker.") {
+            return render_kapi_worker_event(event.canonical_kind(), payload, format);
+        }
         if event.canonical_kind().starts_with("session.") {
             return render_session_event(event.canonical_kind(), payload, format);
         }
@@ -354,6 +357,47 @@ fn agent_inline_suffix(payload: &Value) -> String {
     } else {
         format!(" · {}", parts.join(" · "))
     }
+}
+
+fn render_kapi_worker_event(kind: &str, payload: &Value, format: &MessageFormat) -> Result<String> {
+    if matches!(format, MessageFormat::Raw) {
+        return Ok(serde_json::to_string_pretty(payload)?);
+    }
+
+    let repo = optional_string_field(payload, "repo_name")
+        .or_else(|| optional_string_field(payload, "repo"))
+        .unwrap_or_else(|| "kapi".to_string());
+    let slug = optional_string_field(payload, "slug")
+        .or_else(|| optional_string_field(payload, "worker_id"))
+        .or_else(|| optional_string_field(payload, "tmux_session"))
+        .unwrap_or_else(|| "worker".to_string());
+    let status = optional_string_field(payload, "status").unwrap_or_else(|| {
+        kind.strip_prefix("kapi.worker.")
+            .unwrap_or(kind)
+            .to_string()
+    });
+    let mut parts = Vec::new();
+    if let Some(reason) = optional_string_field(payload, "reason") {
+        parts.push(format!("reason={reason}"));
+    }
+    if let Some(action) = optional_string_field(payload, "recommended_action") {
+        parts.push(format!("action=`{action}`"));
+    }
+    if let Some(mode) = optional_string_field(payload, "mode") {
+        parts.push(format!("mode={mode}"));
+    }
+    let detail = if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join(", "))
+    };
+
+    Ok(match format {
+        MessageFormat::Compact => format!("kapi {repo} {slug} {status}{detail}"),
+        MessageFormat::Alert => format!("🚨 kapi {repo} {slug} {status}{detail}"),
+        MessageFormat::Inline => format!("[kapi:{repo}/{slug}] {status}{detail}"),
+        MessageFormat::Raw => unreachable!(),
+    })
 }
 
 fn render_session_event(kind: &str, payload: &Value, format: &MessageFormat) -> Result<String> {

--- a/src/router.rs
+++ b/src/router.rs
@@ -251,6 +251,7 @@ fn route_candidates(kind: &str) -> Vec<&str> {
         | "session.handoff-needed" => {
             vec![kind, "session.*"]
         }
+        other if other.starts_with("kapi.worker.") => vec![other, "kapi.worker.*", "kapi.*"],
         other => vec![other],
     }
 }

--- a/src/source/kapi.rs
+++ b/src/source/kapi.rs
@@ -1,0 +1,439 @@
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::{Map, Value, json};
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::time::sleep;
+
+use crate::Result;
+use crate::config::{AppConfig, KapiRepoMonitor};
+use crate::events::{IncomingEvent, MessageFormat};
+use crate::source::Source;
+
+pub struct KapiSource {
+    config: Arc<AppConfig>,
+}
+
+impl KapiSource {
+    pub fn new(config: Arc<AppConfig>) -> Self {
+        Self { config }
+    }
+}
+
+#[async_trait::async_trait]
+impl Source for KapiSource {
+    fn name(&self) -> &str {
+        "kapi"
+    }
+
+    async fn run(&self, tx: mpsc::Sender<IncomingEvent>) -> Result<()> {
+        loop {
+            for monitor in &self.config.monitors.kapi.repos {
+                if let Err(error) = poll_and_send_monitor(monitor, Some(&tx)).await {
+                    eprintln!(
+                        "clawhip source kapi polling failed for {}: {error}",
+                        monitor.from
+                    );
+                }
+            }
+
+            sleep(Duration::from_secs(
+                self.config.monitors.poll_interval_secs.max(1),
+            ))
+            .await;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PollOutcome {
+    pub event_count: usize,
+    pub cursor: Option<String>,
+    pub cursor_path: PathBuf,
+}
+
+pub async fn poll_and_send_monitor(
+    monitor: &KapiRepoMonitor,
+    tx: Option<&mpsc::Sender<IncomingEvent>>,
+) -> Result<PollOutcome> {
+    let (events, outcome) = poll_monitor_events(monitor).await?;
+    if let Some(tx) = tx {
+        for event in events {
+            tx.send(event)
+                .await
+                .map_err(|error| format!("kapi source channel closed: {error}"))?;
+        }
+    }
+    Ok(outcome)
+}
+
+pub async fn poll_monitor_events(
+    monitor: &KapiRepoMonitor,
+) -> Result<(Vec<IncomingEvent>, PollOutcome)> {
+    let cursor_path = cursor_path_for_monitor(monitor)?;
+    let since = read_cursor(&cursor_path)?;
+    let raw = run_kapi_events(monitor, since.as_deref()).await?;
+    let parsed = parse_kapi_events_output(&raw)?;
+    let mut next_cursor = parsed.cursor.clone();
+    let mut events = Vec::new();
+
+    for wire in parsed.events {
+        let event = kapi_wire_event_to_incoming(wire, monitor)?;
+        next_cursor = event_cursor(&event).or_else(|| next_cursor.clone());
+        events.push(event);
+    }
+
+    if let Some(cursor) = next_cursor.as_deref() {
+        write_cursor(&cursor_path, cursor)?;
+    }
+
+    let event_count = events.len();
+    Ok((
+        events,
+        PollOutcome {
+            event_count,
+            cursor: next_cursor,
+            cursor_path,
+        },
+    ))
+}
+
+async fn run_kapi_events(monitor: &KapiRepoMonitor, since: Option<&str>) -> Result<String> {
+    let mut command = Command::new(kapi_bin(monitor));
+    command
+        .arg("events")
+        .arg("--from")
+        .arg(&monitor.from)
+        .arg("--json");
+    if let Some(since) = since.filter(|value| !value.trim().is_empty()) {
+        command.arg("--since").arg(since);
+    }
+
+    let output = command.output().await?;
+    if output.status.success() {
+        Ok(String::from_utf8(output.stdout)?.trim().to_string())
+    } else {
+        Err(format!(
+            "kapi events failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )
+        .into())
+    }
+}
+
+fn kapi_bin(monitor: &KapiRepoMonitor) -> String {
+    monitor
+        .kapi_bin
+        .clone()
+        .or_else(|| std::env::var("CLAWHIP_KAPI_BIN").ok())
+        .unwrap_or_else(|| "kapi".to_string())
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedKapiEvents {
+    pub events: Vec<KapiWireEvent>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct KapiWireEvent {
+    pub kind: String,
+    pub channel: Option<String>,
+    pub mention: Option<String>,
+    pub format: Option<MessageFormat>,
+    pub payload: Value,
+}
+
+pub fn parse_kapi_events_output(raw: &str) -> Result<ParsedKapiEvents> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(ParsedKapiEvents {
+            events: Vec::new(),
+            cursor: None,
+        });
+    }
+
+    let value: Value = serde_json::from_str(trimmed)?;
+    match value {
+        Value::Array(values) => Ok(ParsedKapiEvents {
+            events: values
+                .into_iter()
+                .map(kapi_wire_event_from_value)
+                .collect::<Result<Vec<_>>>()?,
+            cursor: None,
+        }),
+        Value::Object(mut object) => {
+            let cursor = string_from_object(&object, &["cursor", "next_cursor", "nextCursor"]);
+            let events_value = object
+                .remove("events")
+                .or_else(|| object.remove("items"))
+                .or_else(|| object.remove("data"));
+            let events = match events_value {
+                Some(Value::Array(values)) => values
+                    .into_iter()
+                    .map(kapi_wire_event_from_value)
+                    .collect::<Result<Vec<_>>>()?,
+                Some(other) => vec![kapi_wire_event_from_value(other)?],
+                None if object.get("type").is_some()
+                    || object.get("kind").is_some()
+                    || object.get("event").is_some() =>
+                {
+                    vec![kapi_wire_event_from_value(Value::Object(object))?]
+                }
+                None => Vec::new(),
+            };
+            Ok(ParsedKapiEvents { events, cursor })
+        }
+        other => Err(format!("unsupported kapi events JSON shape: {other}").into()),
+    }
+}
+
+fn kapi_wire_event_from_value(value: Value) -> Result<KapiWireEvent> {
+    let Value::Object(mut object) = value else {
+        return Err("kapi event entries must be JSON objects".into());
+    };
+
+    let kind = take_string(&mut object, &["type", "kind", "event"])
+        .unwrap_or_else(|| "kapi.worker.output-changed".to_string());
+    let channel = take_string(&mut object, &["channel"]);
+    let mention = take_string(&mut object, &["mention"]);
+    let format = take_string(&mut object, &["format"])
+        .map(|value| MessageFormat::from_label(&value))
+        .transpose()?;
+    let payload = match object.remove("payload") {
+        Some(Value::Object(mut payload)) => {
+            payload.extend(object);
+            Value::Object(payload)
+        }
+        Some(payload) if object.is_empty() => payload,
+        Some(payload) => {
+            let mut merged = Map::new();
+            merged.insert("value".to_string(), payload);
+            merged.extend(object);
+            Value::Object(merged)
+        }
+        None => Value::Object(object),
+    };
+
+    Ok(KapiWireEvent {
+        kind,
+        channel,
+        mention,
+        format,
+        payload,
+    })
+}
+
+pub fn kapi_wire_event_to_incoming(
+    wire: KapiWireEvent,
+    monitor: &KapiRepoMonitor,
+) -> Result<IncomingEvent> {
+    let mut payload = ensure_object_payload(wire.payload);
+    insert_string_if_missing(&mut payload, "repo", Some(monitor.from.clone()));
+    insert_string_if_missing(&mut payload, "source", Some("kapi".to_string()));
+    insert_string_if_missing(
+        &mut payload,
+        "stale_minutes",
+        Some(monitor.stale_minutes.to_string()),
+    );
+
+    let event_channel = wire
+        .channel
+        .or_else(|| string_field(&payload, "discord_topic_id"))
+        .or_else(|| string_field(&payload, "channel"))
+        .or_else(|| monitor.channel.clone());
+    let event_mention = wire.mention.or_else(|| monitor.mention.clone());
+    let event_format = wire.format.or_else(|| monitor.format.clone());
+
+    Ok(IncomingEvent {
+        kind: wire.kind,
+        channel: event_channel,
+        mention: event_mention,
+        format: event_format,
+        template: None,
+        payload,
+    })
+}
+
+fn ensure_object_payload(value: Value) -> Value {
+    match value {
+        Value::Object(_) => value,
+        other => json!({ "value": other }),
+    }
+}
+
+fn insert_string_if_missing(payload: &mut Value, key: &str, value: Option<String>) {
+    let Some(value) = value.filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    if let Some(object) = payload.as_object_mut() {
+        object
+            .entry(key.to_string())
+            .or_insert_with(|| json!(value));
+    }
+}
+
+fn event_cursor(event: &IncomingEvent) -> Option<String> {
+    string_field(&event.payload, "cursor")
+        .or_else(|| string_field(&event.payload, "event_id"))
+        .or_else(|| string_field(&event.payload, "id"))
+}
+
+fn read_cursor(path: &Path) -> Result<Option<String>> {
+    match fs::read_to_string(path) {
+        Ok(value) => Ok(Some(value.trim().to_string()).filter(|value| !value.is_empty())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn write_cursor(path: &Path, cursor: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, format!("{}\n", cursor.trim()))?;
+    Ok(())
+}
+
+pub fn cursor_path_for_monitor(monitor: &KapiRepoMonitor) -> Result<PathBuf> {
+    if let Some(path) = &monitor.cursor_path {
+        return Ok(PathBuf::from(path));
+    }
+
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    Ok(PathBuf::from(home)
+        .join(".clawhip")
+        .join("kapi-cursors")
+        .join(format!("{}.cursor", stable_monitor_key(&monitor.from))))
+}
+
+fn stable_monitor_key(value: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    let hash = hasher.finish();
+    let slug = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .chars()
+        .take(48)
+        .collect::<String>();
+    let slug = if slug.is_empty() { "repo" } else { &slug };
+    format!("{slug}-{hash:016x}")
+}
+
+fn take_string(object: &mut Map<String, Value>, keys: &[&str]) -> Option<String> {
+    for key in keys {
+        if let Some(value) = object.remove(*key).and_then(value_to_string) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn string_from_object(object: &Map<String, Value>, keys: &[&str]) -> Option<String> {
+    keys.iter()
+        .find_map(|key| object.get(*key).and_then(value_to_string_ref))
+}
+
+fn string_field(payload: &Value, key: &str) -> Option<String> {
+    payload.get(key).and_then(value_to_string_ref)
+}
+
+fn value_to_string(value: Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+    .filter(|value| !value.trim().is_empty())
+}
+
+fn value_to_string_ref(value: &Value) -> Option<String> {
+    match value {
+        Value::String(value) => Some(value.clone()),
+        Value::Number(value) => Some(value.to_string()),
+        Value::Bool(value) => Some(value.to_string()),
+        _ => None,
+    }
+    .filter(|value| !value.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn monitor() -> KapiRepoMonitor {
+        KapiRepoMonitor {
+            from: "/repo/kapi".into(),
+            channel: Some("alerts".into()),
+            mention: Some("<@hermes>".into()),
+            stale_minutes: 5,
+            format: Some(MessageFormat::Compact),
+            cursor_path: None,
+            kapi_bin: None,
+        }
+    }
+
+    #[test]
+    fn parses_array_event_output() {
+        let parsed = parse_kapi_events_output(
+            r#"[{"type":"kapi.worker.review-ready","payload":{"slug":"issue-2","cursor":"c1"}}]"#,
+        )
+        .expect("parsed");
+
+        assert_eq!(parsed.events.len(), 1);
+        assert_eq!(parsed.events[0].kind, "kapi.worker.review-ready");
+        assert_eq!(parsed.events[0].payload["slug"], "issue-2");
+    }
+
+    #[test]
+    fn parses_object_with_events_and_cursor() {
+        let parsed = parse_kapi_events_output(
+            r#"{"cursor":"c2","events":[{"type":"kapi.worker.blocked","slug":"issue-2","reason":"needs review"}]}"#,
+        )
+        .expect("parsed");
+
+        assert_eq!(parsed.cursor.as_deref(), Some("c2"));
+        assert_eq!(parsed.events[0].payload["reason"], "needs review");
+    }
+
+    #[test]
+    fn converts_wire_event_with_monitor_defaults_and_topic_override() {
+        let event = kapi_wire_event_to_incoming(
+            KapiWireEvent {
+                kind: "kapi.worker.review-ready".into(),
+                channel: None,
+                mention: None,
+                format: None,
+                payload: json!({
+                    "slug": "issue-2",
+                    "status": "review-ready",
+                    "discord_topic_id": "thread-123",
+                    "recommended_action": "kapi report issue-2 --json"
+                }),
+            },
+            &monitor(),
+        )
+        .expect("event");
+
+        assert_eq!(event.kind, "kapi.worker.review-ready");
+        assert_eq!(event.channel.as_deref(), Some("thread-123"));
+        assert_eq!(event.mention.as_deref(), Some("<@hermes>"));
+        assert_eq!(event.format, Some(MessageFormat::Compact));
+        assert_eq!(event.payload["repo"], "/repo/kapi");
+    }
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,10 +5,12 @@ use crate::events::IncomingEvent;
 
 pub mod git;
 pub mod github;
+pub mod kapi;
 pub mod tmux;
 
 pub use git::GitSource;
 pub use github::GitHubSource;
+pub use kapi::KapiSource;
 pub use tmux::{RegisteredTmuxSession, SharedTmuxRegistry, TmuxSource};
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## Summary
- add `clawhip kapi watch` to poll `kapi events --from <repo> --since <cursor> --json` and forward canonical `kapi.worker.*` events
- add daemon-managed `monitors.kapi.repos` config, cursor persistence, route-family support, and compact Kapi renderer output
- document CLI/config usage for Kapi worker event delivery

## Verification
- cargo fmt --all
- cargo check
- cargo test
- cargo run --quiet -- kapi watch --help